### PR TITLE
feat(Messagerie): Ajout de la gestion multi-récompenses

### DIFF
--- a/app/Enums/Config/MessageRewardTypeEnum.php
+++ b/app/Enums/Config/MessageRewardTypeEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums\Config;
+
+enum MessageRewardTypeEnum: string
+{
+    case ARGENT = 'argent';
+    case TPOINT = 'tpoint';
+    case ENGINE = 'engine';
+}

--- a/app/Models/Config/Service.php
+++ b/app/Models/Config/Service.php
@@ -37,7 +37,7 @@ class Service extends Model
 
     public function users()
     {
-        return $this->hasMany(User::class);
+        return $this->belongsToMany(User::class, 'user_services', 'service_id', 'user_id');
     }
 
     public function versions(): HasMany

--- a/app/Models/Railway/Core/Message.php
+++ b/app/Models/Railway/Core/Message.php
@@ -23,6 +23,11 @@ class Message extends Model
         return $this->belongsTo(Service::class, 'service_id');
     }
 
+    public function rewards()
+    {
+        return $this->hasMany(MessageReward::class);
+    }
+
     public function railway_messages()
     {
         return $this->hasMany(UserRailwayMessage::class);

--- a/app/Models/Railway/Core/MessageReward.php
+++ b/app/Models/Railway/Core/MessageReward.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models\Railway\Core;
+
+use App\Enums\Config\MessageRewardTypeEnum;
+use Illuminate\Database\Eloquent\Model;
+
+class MessageReward extends Model
+{
+    protected $connection = 'mysql';
+    public $timestamps = false;
+    protected $guarded = [];
+    protected $casts = [
+        'reward_type' => MessageRewardTypeEnum::class,
+    ];
+
+    public function message()
+    {
+        return $this->belongsTo(Message::class, 'message_id');
+    }
+}

--- a/app/Models/User/Railway/UserRailwayMessage.php
+++ b/app/Models/User/Railway/UserRailwayMessage.php
@@ -22,7 +22,7 @@ class UserRailwayMessage extends Model
 
     public function message()
     {
-        return $this->belongsTo(Message::class, 'message_id', 'id');
+        return $this->belongsTo(Message::class, 'message_id');
     }
 
     public function markAsRead()

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -102,7 +102,7 @@ class User extends Authenticatable
 
     public function services()
     {
-        return $this->hasMany(UserService::class);
+        return $this->belongsToMany(UserService::class, 'user_services');
     }
 
     public function tickets()

--- a/app/Models/User/UserQuests.php
+++ b/app/Models/User/UserQuests.php
@@ -18,11 +18,11 @@ class UserQuests extends Model
 
     protected function user(): BelongsTo
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class, 'user_id');
     }
 
     protected function railwayQuest(): BelongsTo
     {
-        return $this->belongsTo(RailwayQuest::class);
+        return $this->belongsTo(RailwayQuest::class, 'railway_quest_id');
     }
 }

--- a/app/Models/User/UserReward.php
+++ b/app/Models/User/UserReward.php
@@ -18,11 +18,11 @@ class UserReward extends Model
 
     protected function user(): BelongsTo
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class, 'user_id');
     }
 
     protected function railwayLevelReward(): BelongsTo
     {
-        return $this->belongsTo(RailwayLevelReward::class);
+        return $this->belongsTo(RailwayLevelReward::class, 'railway_level_reward_id');
     }
 }

--- a/app/Models/User/UserService.php
+++ b/app/Models/User/UserService.php
@@ -16,11 +16,11 @@ class UserService extends Model
 
     public function user()
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class, 'user_id');
     }
 
     public function service()
     {
-        return $this->belongsTo(Service::class);
+        return $this->belongsTo(Service::class, 'service_id');
     }
 }

--- a/database/migrations/2024_02_02_172218_create_railway_engines_table.php
+++ b/database/migrations/2024_02_02_172218_create_railway_engines_table.php
@@ -7,24 +7,24 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-            Schema::connection('railway')->create('railway_engines', function (Blueprint $table) {
-                $table->id();
-                $table->uuid();
-                $table->string('name');
-                $table->string('type_transport');
-                $table->string('type_train');
-                $table->string('type_energy')->nullable();
-                $table->time('duration_maintenance')->default('00:00:00');
-                $table->boolean('active')->default(false);
-                $table->boolean('in_shop')->default(false);
-                $table->boolean('in_game')->default(true);
-                $table->string('status');
-                $table->softDeletes();
-            });
+        Schema::connection('railway')->create('railway_engines', function (Blueprint $table) {
+            $table->id();
+            $table->uuid();
+            $table->string('name');
+            $table->string('type_transport');
+            $table->string('type_train');
+            $table->string('type_energy')->nullable();
+            $table->time('duration_maintenance')->default('00:00:00');
+            $table->boolean('active')->default(false);
+            $table->boolean('in_shop')->default(false);
+            $table->boolean('in_game')->default(true);
+            $table->string('status');
+            $table->softDeletes();
+        });
     }
 
     public function down(): void
     {
-            Schema::connection('railway')->dropIfExists('railway_engines');
+        Schema::connection('railway')->dropIfExists('railway_engines');
     }
 };

--- a/database/migrations/2024_04_12_172424_create_authentication_log_table.php
+++ b/database/migrations/2024_04_12_172424_create_authentication_log_table.php
@@ -7,21 +7,34 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-            Schema::connection('railway')->create(config('authentication-log.table_name'), function (Blueprint $table) {
-                $table->id();
-                $table->morphs('authenticatable');
-                $table->string('ip_address', 45)->nullable();
-                $table->text('user_agent')->nullable();
-                $table->timestamp('login_at')->nullable();
-                $table->boolean('login_successful')->default(false);
-                $table->timestamp('logout_at')->nullable();
-                $table->boolean('cleared_by_user')->default(false);
-                $table->json('location')->nullable();
-            });
+        Schema::connection('mysql')->create(config('authentication-log.table_name'), function (Blueprint $table) {
+            $table->id();
+            $table->morphs('authenticatable');
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamp('login_at')->nullable();
+            $table->boolean('login_successful')->default(false);
+            $table->timestamp('logout_at')->nullable();
+            $table->boolean('cleared_by_user')->default(false);
+            $table->json('location')->nullable();
+        });
+
+        Schema::connection('railway')->create(config('authentication-log.table_name'), function (Blueprint $table) {
+            $table->id();
+            $table->morphs('authenticatable');
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamp('login_at')->nullable();
+            $table->boolean('login_successful')->default(false);
+            $table->timestamp('logout_at')->nullable();
+            $table->boolean('cleared_by_user')->default(false);
+            $table->json('location')->nullable();
+        });
     }
 
     public function down(): void
     {
-            Schema::connection('railway')->dropIfExists(config('authentication-log.table_name'));
+        Schema::connection('mysql')->dropIfExists(config('authentication-log.table_name'));
+        Schema::connection('railway')->dropIfExists(config('authentication-log.table_name'));
     }
 };

--- a/database/migrations/2024_05_13_181431_create_user_railway_messages_table.php
+++ b/database/migrations/2024_05_13_181431_create_user_railway_messages_table.php
@@ -7,18 +7,18 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-            Schema::connection('railway')->create('user_railway_messages', function (Blueprint $table) {
-                $table->id();
-                $table->foreignId('user_id');
-                $table->foreignId('message_id');
-                $table->boolean('is_read')->default(false);
-                $table->boolean('reward_collected')->default(false);
-                $table->timestamps();
-            });
+        Schema::connection('railway')->create('user_railway_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->foreignId('message_id');
+            $table->boolean('is_read')->default(false);
+            $table->boolean('reward_collected')->default(false);
+            $table->timestamps();
+        });
     }
 
     public function down(): void
     {
-            Schema::connection('railway')->dropIfExists('user_railway_messages');
+        Schema::connection('railway')->dropIfExists('user_railway_messages');
     }
 };

--- a/database/migrations/2024_05_16_004117_create_user_railway_bonuses_table.php
+++ b/database/migrations/2024_05_16_004117_create_user_railway_bonuses_table.php
@@ -7,17 +7,17 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-            Schema::connection('railway')->create('user_railway_bonuses', function (Blueprint $table) {
-                $table->id();
-                $table->integer('simulation');
-                $table->integer('audit_ext');
-                $table->integer('audit_int');
-                $table->foreignId('user_id');
-            });
+        Schema::connection('railway')->create('user_railway_bonuses', function (Blueprint $table) {
+            $table->id();
+            $table->integer('simulation')->default(0);
+            $table->integer('audit_ext')->default(0);
+            $table->integer('audit_int')->default(0);
+            $table->foreignId('user_id');
+        });
     }
 
     public function down(): void
     {
-            Schema::connection('railway')->dropIfExists('user_railway_bonuses');
+        Schema::connection('railway')->dropIfExists('user_railway_bonuses');
     }
 };

--- a/database/migrations/2024_05_17_234042_create_message_rewards_table.php
+++ b/database/migrations/2024_05_17_234042_create_message_rewards_table.php
@@ -13,7 +13,7 @@ return new class extends Migration {
             $table->bigInteger('reward_value');
             $table->integer('reward_item_id')->unsigned()->nullable()->comment("ID de l'objet si lié à un objet dans reward_type");
 
-            $table->foreign('message_id');
+            $table->foreignId('message_id');
         });
     }
 

--- a/database/migrations/2024_05_17_234042_create_message_rewards_table.php
+++ b/database/migrations/2024_05_17_234042_create_message_rewards_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::connection('mysql')->create('message_rewards', function (Blueprint $table) {
+            $table->id();
+            $table->string('reward_type');
+            $table->bigInteger('reward_value');
+            $table->integer('reward_item_id')->unsigned()->nullable()->comment("ID de l'objet si lié à un objet dans reward_type");
+
+            $table->foreign('message_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection('mysql')->dropIfExists('message_rewards');
+    }
+};

--- a/resources/views/livewire/account/mailboxes.blade.php
+++ b/resources/views/livewire/account/mailboxes.blade.php
@@ -38,7 +38,7 @@
                                 <div class="card-header">
                                     <h3 class="card-title">{{ $message->message->message_subject }}</h3>
                                     <div class="card-toolbar">
-                                        @if($message->message->rewards()->count > 0 && !$message->reward_collected)
+                                        @if($message->message->rewards()->count() > 0 && !$message->reward_collected)
                                             <button wire:click="claim({{ $message->id }})" type="button" class="btn btn-sm btn-light">
                                                 Réclamer
                                             </button>
@@ -48,21 +48,23 @@
                                 <div class="card-body">
                                     {!! $message->message->message_content !!}
                                 </div>
-                                @if($message->message->rewards()->count > 0)
+                                @if($message->message->rewards()->count() > 0)
                                     <div class="card-footer">
-                                        @foreach($message->message->rewards as $reward)
-                                            <div class="d-flex flex-column align-items-center justify-content-center">
-                                                <div class="symbol symbol-100px symbol-circle mb-2">
-                                                    <img src="{{ Storage::url('icons/railway/'.$message->reward_type->value.'.png') }}" alt="">
-                                                    @if($message->reward_collected)
-                                                        <span class="symbol-badge badge badge-circle badge-light start-100">
+                                        <div class="d-flex flex-row justify-content-center gap-5">
+                                            @foreach($message->message->rewards as $reward)
+                                                <div class="d-flex flex-column align-items-center justify-content-center rounded-1 border border-primary p-3">
+                                                    <div class="symbol symbol-100px symbol-circle mb-2">
+                                                        <img src="{{ Storage::url('icons/railway/'.$reward->reward_type->value.'.png') }}" alt="">
+                                                        @if($message->reward_collected)
+                                                            <span class="symbol-badge badge badge-circle badge-light start-100">
                                                         <i class="fa-solid fa-check text-success"></i>
                                                     </span>
-                                                    @endif
+                                                        @endif
+                                                    </div>
+                                                    <span class="badge badge-lg badge-light">{{ number_format($reward->reward_value, 0, ',', ' ') }}</span>
                                                 </div>
-                                                <span class="badge badge-lg badge-light">{{ number_format($message->reward_value, 0, ',', ' ') }}</span>
-                                            </div>
-                                        @endforeach
+                                            @endforeach
+                                        </div>
                                     </div>
                                 @endif
                             </div>

--- a/resources/views/livewire/account/mailboxes.blade.php
+++ b/resources/views/livewire/account/mailboxes.blade.php
@@ -11,10 +11,10 @@
                                     <span class="fs-2 fw-bold">{{ $message->message->message_subject }}</span>
                                     <span class="fs-6 text-muted">{{ $message->created_at->diffForHumans() }}</span>
                                 </span>
-                                @if(!empty($message->reward_type))
+                                @if($message->message->rewards()->count() > 0)
                                     <span class="d-flex flex-grow-0 border border-2 border-primary border-active-info rounded-3 p-2">
                                         <span class="symbol symbol-70px">
-                                            <img src="{{ Storage::url('icons/railway/'.$message->reward_type->value.'.png') }}" alt="">
+                                            <img src="{{ Storage::url('icons/railway/'.$message->message->rewards()->first()->reward_type->value.'.png') }}" alt="">
                                             @if($message->reward_collected)
                                                 <span class="symbol-badge badge badge-circle badge-light start-100">
                                                     <i class="fa-solid fa-check text-success"></i>
@@ -38,7 +38,7 @@
                                 <div class="card-header">
                                     <h3 class="card-title">{{ $message->message->message_subject }}</h3>
                                     <div class="card-toolbar">
-                                        @if(isset($message->reward_type) && !$message->reward_collected)
+                                        @if($message->message->rewards()->count > 0 && !$message->reward_collected)
                                             <button wire:click="claim({{ $message->id }})" type="button" class="btn btn-sm btn-light">
                                                 Réclamer
                                             </button>
@@ -48,19 +48,21 @@
                                 <div class="card-body">
                                     {!! $message->message->message_content !!}
                                 </div>
-                                @if($message->reward_type)
+                                @if($message->message->rewards()->count > 0)
                                     <div class="card-footer">
-                                        <div class="d-flex flex-column align-items-center justify-content-center">
-                                            <div class="symbol symbol-100px symbol-circle mb-2">
-                                                <img src="{{ Storage::url('icons/railway/'.$message->reward_type->value.'.png') }}" alt="">
-                                                @if($message->reward_collected)
-                                                    <span class="symbol-badge badge badge-circle badge-light start-100">
-                                                    <i class="fa-solid fa-check text-success"></i>
-                                                </span>
-                                                @endif
+                                        @foreach($message->message->rewards as $reward)
+                                            <div class="d-flex flex-column align-items-center justify-content-center">
+                                                <div class="symbol symbol-100px symbol-circle mb-2">
+                                                    <img src="{{ Storage::url('icons/railway/'.$message->reward_type->value.'.png') }}" alt="">
+                                                    @if($message->reward_collected)
+                                                        <span class="symbol-badge badge badge-circle badge-light start-100">
+                                                        <i class="fa-solid fa-check text-success"></i>
+                                                    </span>
+                                                    @endif
+                                                </div>
+                                                <span class="badge badge-lg badge-light">{{ number_format($message->reward_value, 0, ',', ' ') }}</span>
                                             </div>
-                                            <span class="badge badge-lg badge-light">{{ number_format($message->reward_value, 0, ',', ' ') }}</span>
-                                        </div>
+                                        @endforeach
                                     </div>
                                 @endif
                             </div>

--- a/resources/views/livewire/core/news-panel.blade.php
+++ b/resources/views/livewire/core/news-panel.blade.php
@@ -47,7 +47,7 @@
                         <div class="col-md-4 h-450px hover-scroll-y">
                             <ul class="nav nav-pills nav-pills-custom" role="tablist">
                                 @foreach($notices as $notice)
-                                    <li class="nav-item w-100">
+                                    <li class="nav-item w-100 mb-5">
                                         <a wire:click.prevent="read({{ $notice->id }})" class="d-flex btn btn-flex btn-outline btn-color-muted btn-active-color-warning btn-active-gray flex-row overflow-hidden h-100px showNotice" data-article-id="{{ $notice->id }}" href="#notice_{{ $notice->id }}" data-bs-toggle="pill" role="tab">
                                             <span class="noticeUnread"></span>
                                             <span class="fs-3 fs-3">{{ $notice->title }}</span>


### PR DESCRIPTION
- Normalisation des relations 'belongsTo' pour spécifier les clés étrangères
- Refactorisation de plusieurs migrations pour améliorer la lisibilité
- Ajout de la méthode 'rewards' dans le modèle 'Message'
- Duplication de la migration 'authentication-log' pour la connexion 'mysql'
- Création du modèle MessageReward
- Mise en place de la migration pour la table message_rewards
- Ajout de l'énumération MessageRewardTypeEnum pour le typage du champ reward_type dans le modèle MessageReward
- Changement de 'hasMany' à 'belongsToMany' pour les relations UserService dans User.php et Service.php
- Mise à jour de la définition de la colonne étrangère dans create_message_rewards_table.php
- Ajout de valeurs par défaut aux colonnes 'simulation', 'audit_ext', 'audit_int' dans create_user_railway_bonuses_table.php
- Ajustement de l'indentation dans create_user_railway_bonuses_table.php
…e de notifications
- Changement de l'utilisation de reward_type à rewards() dans les conditions
- Ajout d'une boucle pour itérer sur toutes les récompenses d'un message
- Mise à jour des références à reward_type et reward_value pour utiliser l'objet de récompense dans la boucle
- Ajustement des chemins d'accès aux icônes de récompense pour utiliser l'objet de récompense dans la boucle
- Modification du système de récompense pour gérer plusieurs récompenses par message
- Correction d'erreurs dans l'affichage des récompenses
- Optimisation de la sélection des données du message