### PR TITLE
ci(github-action): mise à jour du fichier de configuration des workflows

### DIFF
--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -18,6 +18,8 @@ jobs:
         run: |
           curl -fsSL https://ollama.com/install.sh | sh
           ollama pull llama3
+          OLLAMA_HOST="127.0.0.1:11434"
+          systemctl start ollama
         shell: bash
 
   pr_updater:

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -1,46 +1,23 @@
-name: "Ollama PR Updater"
+name: "Generate PR Description"
 on:
-  workflow_dispatch:
-
-permissions:
-  contents: read
+  pull_request:
+    types: [opened]
 
 jobs:
-  install_ollama:
+  generate-pr:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
+      - name: Run PR Auto on initial open PR
+        id: pr_auto_id
+        uses: vblagoje/pr-auto@v1
         with:
-          fetch-depth: 0
+          openai_api_key: ${{ secrets.AI_KEY }}
+          openai_base_url: http://82.64.133.182:11434/api/generate
+          generation_model: llama3
+          user_prompt: ${{ github.event.pull_request.body }}
 
-      - name: Install Ollama
-        run: |
-          curl -fsSL https://ollama.com/install.sh | sh
-          ollama pull llama3
-          OLLAMA_HOST="127.0.0.1:11434"
-          systemctl start ollama
-        shell: bash
-
-  pr_updater:
-    needs: install_ollama
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get changed file
-        id: changed-file
-        uses: tj-actions/changed-files@v43
-
-      - name: Revue du code
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            review=$(curl -s http://127.0.0.1:11434/api/generate -d '{"model": "llama3", "prompt": "Consultez le fichier suivant:\n\n```\n$(cat $file)\n```", "stream": false}' | jq -r '.response')
-            comment="Ollama Code Review for \`$file\`:\n\n$review"
-            echo "$comment" >> ollama_review.txt
-          done
-          gh pr comment ${{ github.event.pull_request.number }} --body "$(cat ollama_review.txt)"
-
-        shell: bash
-
-
+      - name: Update PR description
+        uses: vblagoje/update-pr@v1
+        with:
+          pr-body: ${{ steps.pr_auto_id.outputs.pr-text }}


### PR DESCRIPTION
- Ajout d'un hôte OLLAMA spécifique
- Démarrage du service Ollama
- Suppression de la tâche d'installation d'Ollama
- Ajout de la génération de la description des PR
- Modification du déclencheur de workflow de "workflow_dispatch" en "pull_request"
- Rajout de l'utilisation de l'action vblagoje/pr-auto pour les PRs ouvertes
- Mise à jour de la description de la PR avec l'action vblago